### PR TITLE
Fix #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
   - 서버 주소: http://localhost:30771
   - 매뉴얼
     - **Swagger Editor**: [dist/swagger.json](https://editor.swagger.io/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsamchon%2Ffake-toss-payments-server%2Fmaster%2Fdist%2Fswagger.json)
-    - 자료 구조: [src/api/structures/ITossBilling.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/api/structures/ITossBilling.ts)
-    - API 함수: [src/api/functional/payments/index.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/api/functional/payments/index.ts)
+    - 자료 구조: [src/api/structures/ITossBilling.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/api/structures/ITossBilling.ts)
+    - API 함수: [src/api/functional/payments/index.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/api/functional/payments/index.ts)
     - 예제 코드
-      - 간편 결제: [test_fake_billing_payment.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/test/features/examples/test_fake_billing_payment.ts)
-      - 카드 결제: [test_fake_card_payment.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/test/features/examples/test_fake_card_payment.ts)
-      - 가상 계좌 결제: [test_fake_virtual_account_payment.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/test/features/examples/test_fake_virtual_account_payment.ts)
-      - 현금 영수증 발행: [test_fake_cash_receipt.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/test/features/examples/test_fake_cash_receipt.ts)
+      - 간편 결제: [test_fake_billing_payment.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/test/features/examples/test_fake_billing_payment.ts)
+      - 카드 결제: [test_fake_card_payment.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/test/features/examples/test_fake_card_payment.ts)
+      - 가상 계좌 결제: [test_fake_virtual_account_payment.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/test/features/examples/test_fake_virtual_account_payment.ts)
+      - 현금 영수증 발행: [test_fake_cash_receipt.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/test/features/examples/test_fake_cash_receipt.ts)
   - 연관 저장소
     - [samchon/netia](https://github.com/samchon/nestia) - Automatic SDK generator for the NestJS
     - [samchon/fake-iamport-server](https://github.com/samchon/fake-iamport-server): 가짜 아임포트 서버
@@ -157,13 +157,13 @@ npm install --save fake-toss-payments-server-api
   - 서버 주소: http://localhost:30771
   - 매뉴얼
     - **Swagger Editor**: [dist/swagger.json](https://editor.swagger.io/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsamchon%2Ffake-toss-payments-server%2Fmaster%2Fdist%2Fswagger.json)
-    - 자료 구조: [src/api/structures/ITossBilling.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/api/structures/ITossBilling.ts)
-    - API 함수: [src/api/functional/payments/index.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/api/functional/payments/index.ts)
+    - 자료 구조: [src/api/structures/ITossBilling.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/api/structures/ITossBilling.ts)
+    - API 함수: [src/api/functional/payments/index.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/api/functional/payments/index.ts)
     - 예제 코드
-      - 간편 결제: [test_fake_billing_payment.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/test/features/examples/test_fake_billing_payment.ts)
-      - 카드 결제: [test_fake_card_payment.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/test/features/examples/test_fake_card_payment.ts)
-      - 가상 계좌 결제: [test_fake_virtual_account_payment.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/test/features/examples/test_fake_virtual_account_payment.ts)
-      - 현금 영수증 발행: [test_fake_cash_receipt.ts](https://github.surf/samchon/fake-toss-payments-server/blob/HEAD/src/test/features/examples/test_fake_cash_receipt.ts)
+      - 간편 결제: [test_fake_billing_payment.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/test/features/examples/test_fake_billing_payment.ts)
+      - 카드 결제: [test_fake_card_payment.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/test/features/examples/test_fake_card_payment.ts)
+      - 가상 계좌 결제: [test_fake_virtual_account_payment.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/test/features/examples/test_fake_virtual_account_payment.ts)
+      - 현금 영수증 발행: [test_fake_cash_receipt.ts](https://github.com/samchon/fake-toss-payments-server/blob/master/src/test/features/examples/test_fake_cash_receipt.ts)
   - 연관 저장소
     - [samchon/netia](https://github.com/samchon/nestia) - Automatic SDK generator for the NestJS
     - [samchon/fake-iamport-server](https://github.com/samchon/fake-iamport-server): 가짜 아임포트 서버


### PR DESCRIPTION
`github.surf` 가 죽었다. 이에 `github.surf` 로 걸어놨던 링크를, 모두 깃허브 본연의 것으로 되돌림.

@imjlk 님, 제보 감사합니다.